### PR TITLE
Add discover command and Nix flake

### DIFF
--- a/cmd/dankcalendar/cmd_discover.go
+++ b/cmd/dankcalendar/cmd_discover.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/alcxyz/DankCalendar/internal/caldav"
+	"github.com/alcxyz/DankCalendar/internal/config"
+	"github.com/alcxyz/DankCalendar/internal/keyring"
+	"github.com/alcxyz/DankCalendar/internal/output"
+)
+
+func cmdDiscover(args []string) {
+	fs := flag.NewFlagSet("discover", flag.ExitOnError)
+	url := fs.String("url", "", "CalDAV server URL")
+	user := fs.String("username", "", "CalDAV username")
+	pw := fs.String("password", "", "CalDAV password")
+	fs.Parse(args)
+
+	if *url == "" || *user == "" || *pw == "" {
+		exitError("--url, --username, and --password are all required")
+	}
+
+	// Store password in keyring
+	if !keyring.Available() {
+		exitError("secret-tool is not installed — install libsecret-tools")
+	}
+	if err := keyring.Store(*user, *pw); err != nil {
+		exitError("keyring: " + err.Error())
+	}
+
+	// Discover calendars
+	client, err := caldav.NewClient(*url, *user, *pw)
+	if err != nil {
+		exitError(err.Error())
+	}
+
+	discovered, err := client.Discover()
+	if err != nil {
+		output.JSON(map[string]any{
+			"success":   false,
+			"error":     err.Error(),
+			"calendars": []string{},
+		})
+		return
+	}
+
+	if len(discovered) == 0 {
+		output.JSON(map[string]any{
+			"success":   false,
+			"error":     "no calendars found",
+			"calendars": []string{},
+		})
+		return
+	}
+
+	// Detect timezone
+	tz := detectTimezone()
+
+	// Build and save config
+	var cals []config.Calendar
+	for _, d := range discovered {
+		cals = append(cals, config.Calendar{
+			URL:      d.URL,
+			Username: *user,
+		})
+	}
+
+	cfg := &config.Config{
+		Timezone:  tz,
+		Calendars: cals,
+	}
+	if err := config.Save(cfg); err != nil {
+		exitError("save config: " + err.Error())
+	}
+
+	names := make([]string, len(discovered))
+	for i, d := range discovered {
+		names[i] = d.Name
+	}
+
+	output.JSON(map[string]any{
+		"success":   true,
+		"calendars": names,
+	})
+}

--- a/cmd/dankcalendar/main.go
+++ b/cmd/dankcalendar/main.go
@@ -16,7 +16,8 @@ var commands = map[string]string{
 	"edit":      "Modify an existing event",
 	"delete":    "Delete an event",
 	"notify":    "Send desktop notifications for upcoming events",
-	"setup":     "Configure CalDAV credentials",
+	"setup":     "Configure CalDAV credentials (interactive)",
+	"discover":  "Discover calendars and store credentials (non-interactive)",
 }
 
 func main() {
@@ -47,6 +48,8 @@ func main() {
 		cmdNotify(args)
 	case "setup":
 		cmdSetup(args)
+	case "discover":
+		cmdDiscover(args)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
 		usage()

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoModule, version ? "dev" }:
+
+buildGoModule {
+  pname = "dankcalendar";
+  inherit version;
+
+  src = ./.;
+
+  vendorHash = null;
+
+  subPackages = [ "cmd/dankcalendar" ];
+
+  ldflags = [ "-s" "-w" "-X main.version=${version}" ];
+
+  meta = with lib; {
+    description = "CalDAV CLI client for DankMaterialShell";
+    homepage = "https://github.com/alcxyz/DankCalendar";
+    license = licenses.mit;
+    mainProgram = "dankcalendar";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "CalDAV CLI client for DankMaterialShell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = builtins.replaceStrings ["\n"] [""] (builtins.readFile ./VERSION);
+      in {
+        packages = rec {
+          dankcalendar = pkgs.callPackage ./default.nix { inherit version; };
+          default = dankcalendar;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ go gopls gotools ];
+        };
+      }
+    );
+}

--- a/test.sh
+++ b/test.sh
@@ -59,6 +59,7 @@ assert_contains "help shows edit command" "edit" "$HELP"
 assert_contains "help shows delete command" "delete" "$HELP"
 assert_contains "help shows notify command" "notify" "$HELP"
 assert_contains "help shows setup command" "setup" "$HELP"
+assert_contains "help shows discover command" "discover" "$HELP"
 
 VERSION_OUT=$(./dankcalendar --version 2>&1)
 assert_eq "version output matches VERSION file" "$VERSION" "$VERSION_OUT"


### PR DESCRIPTION
## Summary
- Add `discover` command for non-interactive QML integration (takes --url, --username, --password)
- Add `flake.nix` + `default.nix` for Nix packaging (buildGoModule, vendorHash=null)

## Test plan
- [x] `nix build` produces working binary
- [x] 27 test.sh assertions pass
- [x] Go unit tests pass