### PR TITLE
fix: use plugin id in nix install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ go build -o dankcalendar ./cmd/dankcalendar
 
 ## Design
 
-- **Single binary** - no Python, no submodules
-- **Stdlib-only** - no external Go dependencies
-- **Keyring-only** - passwords stored via `secret-tool`, never in config files
-- **Security by default** - HTTPS-only, ICS escaping, path traversal protection, `0600` config
-- **JSON output** - one JSON object per command on stdout, errors on stderr
-- **Timezone-aware** - events from all calendars normalised to the configured timezone for correct cross-calendar sorting
-- **Recurring events** - server-side expansion via CalDAV `<expand>` with client-side RRULE fallback for subscribed calendars
+- **Single binary** — no Python, no submodules
+- **Stdlib-only** — no external Go dependencies
+- **Keyring-only** — passwords stored via `secret-tool`, never in config files
+- **Security by default** — HTTPS-only, ICS escaping, path traversal protection, `0600` config
+- **JSON output** — one JSON object per command on stdout, errors on stderr
+- **Timezone-aware** — events from all calendars normalised to the configured timezone for correct cross-calendar sorting
+- **Recurring events** — server-side expansion via CalDAV `<expand>` with client-side RRULE fallback for subscribed calendars
 
 See [docs/adr/](docs/adr/) for architectural decision records.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ inputs.dms-plugin-calendar = {
 ```
 
 ```nix
-programs.dank-material-shell.plugins.DankCalendar = {
+programs.dank-material-shell.plugins.dankCalendar = {
   enable = true;
   src = inputs.dms-plugin-calendar;
 };
@@ -62,13 +62,13 @@ go build -o dankcalendar ./cmd/dankcalendar
 
 ## Design
 
-- **Single binary** — no Python, no submodules
-- **Stdlib-only** — no external Go dependencies
-- **Keyring-only** — passwords stored via `secret-tool`, never in config files
-- **Security by default** — HTTPS-only, ICS escaping, path traversal protection, `0600` config
-- **JSON output** — one JSON object per command on stdout, errors on stderr
-- **Timezone-aware** — events from all calendars normalised to the configured timezone for correct cross-calendar sorting
-- **Recurring events** — server-side expansion via CalDAV `<expand>` with client-side RRULE fallback for subscribed calendars
+- **Single binary** - no Python, no submodules
+- **Stdlib-only** - no external Go dependencies
+- **Keyring-only** - passwords stored via `secret-tool`, never in config files
+- **Security by default** - HTTPS-only, ICS escaping, path traversal protection, `0600` config
+- **JSON output** - one JSON object per command on stdout, errors on stderr
+- **Timezone-aware** - events from all calendars normalised to the configured timezone for correct cross-calendar sorting
+- **Recurring events** - server-side expansion via CalDAV `<expand>` with client-side RRULE fallback for subscribed calendars
 
 See [docs/adr/](docs/adr/) for architectural decision records.
 


### PR DESCRIPTION
Updates the Nix install example to use the manifest id `dankCalendar` as the plugin key, matching how DMS stores plugin settings.