### PR TITLE
ci: check remote tags before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         id: tag
         run: |
           VERSION="v$(jq -r .version plugin.json)"
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+          if git tag -l "$VERSION" | grep -q . || git ls-remote --tags origin "$VERSION" | grep -q .; then
             echo "Tag $VERSION already exists, skipping."
             echo "created=false" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- harden the auto-tag guard to check remote tags as well as local tags
- avoid duplicate release creation if the version tag already exists remotely

## Validation
- bash test.sh currently has an existing failure: CLI JSON error-output assertion