### PR TITLE
ci: use go.mod for workflow Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Build binary
         run: go build -ldflags "-X main.version=$(jq -r .version plugin.json)" -o dankcalendar ./cmd/dankcalendar


### PR DESCRIPTION
Reads the CI Go version from go.mod so the workflow matches the module requirement instead of pinning Go 1.22.