### PR TITLE
Release v0.6.0

### DIFF
--- a/CalendarSettings.qml
+++ b/CalendarSettings.qml
@@ -78,6 +78,13 @@ PluginSettings {
     }
 
     ToggleSetting {
+        settingKey: "showDescription"
+        label: "Show event details"
+        description: "Display event details for events that have them"
+        defaultValue: true
+    }
+
+    ToggleSetting {
         settingKey: "showCalendarName"
         label: "Show calendar name"
         description: "Display which calendar each event belongs to"

--- a/CalendarWidget.qml
+++ b/CalendarWidget.qml
@@ -47,6 +47,7 @@ PluginComponent {
     }
     property bool addAllDay: false
     property string addLocation: ""
+    property string addDescription: ""
 
     // Edit event form state
     property bool showEditForm: false
@@ -57,6 +58,7 @@ PluginComponent {
     property bool editAllDay: false
     property string editError: ""
     property string editLocation: ""
+    property string editDescription: ""
 
     // ── Internal ────────────────────────────────────────────────────
     property string _pendingOutput: ""
@@ -281,6 +283,7 @@ PluginComponent {
         }
 
         if (addLocation) { cmd.push("--location"); cmd.push(addLocation); }
+        if (addDescription) { cmd.push("--description"); cmd.push(addDescription); }
         addProc.command = cmd;
         addProc.running = true;
     }
@@ -297,6 +300,7 @@ PluginComponent {
                 if (json.success) {
                     root.addTitle = "";
                     root.addLocation = "";
+                    root.addDescription = "";
                     root.addStartDate = new Date();
                     var d = new Date();
                     d.setHours(d.getHours() + 1);
@@ -319,6 +323,7 @@ PluginComponent {
         editTitle = ev.title;
         editAllDay = ev.allDay;
         editLocation = ev.location || "";
+        editDescription = ev.description || "";
         editError = "";
 
         if (ev.allDay) {
@@ -364,6 +369,8 @@ PluginComponent {
 
         cmdArgs.push("--location");
         cmdArgs.push(editLocation);
+        cmdArgs.push("--description");
+        cmdArgs.push(editDescription);
 
         _editOutput = "";
         editProc.command = cmdArgs;
@@ -862,6 +869,43 @@ PluginComponent {
 
                     leftPadding: Theme.spacingS
                     verticalAlignment: TextInput.AlignVCenter
+                }
+
+                // Details
+                TextEdit {
+                    width: parent.width
+                    height: Math.max(76, contentHeight + Theme.spacingM)
+                    text: root.addDescription
+                    color: Theme.surfaceText
+                    font.pixelSize: Theme.fontSizeMedium
+                    wrapMode: TextEdit.Wrap
+                    selectByMouse: true
+                    onTextChanged: root.addDescription = text
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: "transparent"
+                        border.width: 1
+                        border.color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                        radius: Theme.cornerRadius
+                        z: -1
+                    }
+
+                    Text {
+                        text: "Details (optional)"
+                        color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                        font.pixelSize: Theme.fontSizeMedium
+                        anchors.top: parent.top
+                        anchors.topMargin: Theme.spacingS
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS
+                        visible: root.addDescription === ""
+                    }
+
+                    leftPadding: Theme.spacingS
+                    rightPadding: Theme.spacingS
+                    topPadding: Theme.spacingS
+                    bottomPadding: Theme.spacingS
                 }
 
                 // ── Calendar grid date picker ──────────────────────
@@ -1409,6 +1453,43 @@ PluginComponent {
                     verticalAlignment: TextInput.AlignVCenter
                 }
 
+                // Details
+                TextEdit {
+                    width: parent.width
+                    height: Math.max(76, contentHeight + Theme.spacingM)
+                    text: root.editDescription
+                    color: Theme.surfaceText
+                    font.pixelSize: Theme.fontSizeMedium
+                    wrapMode: TextEdit.Wrap
+                    selectByMouse: true
+                    onTextChanged: root.editDescription = text
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: "transparent"
+                        border.width: 1
+                        border.color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                        radius: Theme.cornerRadius
+                        z: -1
+                    }
+
+                    Text {
+                        text: "Details (optional)"
+                        color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                        font.pixelSize: Theme.fontSizeMedium
+                        anchors.top: parent.top
+                        anchors.topMargin: Theme.spacingS
+                        anchors.left: parent.left
+                        anchors.leftMargin: Theme.spacingS
+                        visible: root.editDescription === ""
+                    }
+
+                    leftPadding: Theme.spacingS
+                    rightPadding: Theme.spacingS
+                    topPadding: Theme.spacingS
+                    bottomPadding: Theme.spacingS
+                }
+
                 // Calendar grid for edit
                 Column {
                     width: parent.width
@@ -1723,6 +1804,17 @@ PluginComponent {
                                         font.pixelSize: Theme.fontSizeSmall
                                         visible: root.showLocation && (modelData.location || "") !== ""
                                         width: parent.width
+                                        elide: Text.ElideRight
+                                    }
+
+                                    StyledText {
+                                        text: modelData.description
+                                        color: Theme.surfaceVariantText
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        visible: (modelData.description || "") !== ""
+                                        width: parent.width
+                                        wrapMode: Text.WordWrap
+                                        maximumLineCount: 2
                                         elide: Text.ElideRight
                                     }
 

--- a/CalendarWidget.qml
+++ b/CalendarWidget.qml
@@ -13,6 +13,7 @@ PluginComponent {
     property int lookAheadDays: 14
     property int refreshInterval: 5       // minutes
     property bool showLocation: true
+    property bool showDescription: true
     property bool showCalendarName: true
     property bool hidePastEvents: false
     property bool showMeetLink: true
@@ -75,6 +76,7 @@ PluginComponent {
         lookAheadDays = pluginService.loadPluginData(pluginId, "lookAheadDays", 14) || 14;
         refreshInterval = pluginService.loadPluginData(pluginId, "refreshInterval", 5) || 5;
         showLocation = pluginService.loadPluginData(pluginId, "showLocation", true) !== false;
+        showDescription = pluginService.loadPluginData(pluginId, "showDescription", true) !== false;
         showCalendarName = pluginService.loadPluginData(pluginId, "showCalendarName", true) !== false;
         hidePastEvents = pluginService.loadPluginData(pluginId, "hidePastEvents", false) === true;
         showMeetLink = pluginService.loadPluginData(pluginId, "showMeetLink", true) !== false;
@@ -871,41 +873,51 @@ PluginComponent {
                     verticalAlignment: TextInput.AlignVCenter
                 }
 
-                // Details
-                TextEdit {
+                Column {
                     width: parent.width
-                    height: Math.max(76, contentHeight + Theme.spacingM)
-                    text: root.addDescription
-                    color: Theme.surfaceText
-                    font.pixelSize: Theme.fontSizeMedium
-                    wrapMode: TextEdit.Wrap
-                    selectByMouse: true
-                    onTextChanged: root.addDescription = text
+                    spacing: Theme.spacingXS
 
-                    Rectangle {
-                        anchors.fill: parent
-                        color: "transparent"
-                        border.width: 1
-                        border.color: Theme.withAlpha(Theme.surfaceText, 0.3)
-                        radius: Theme.cornerRadius
-                        z: -1
+                    StyledText {
+                        text: "Details"
+                        font.pixelSize: Theme.fontSizeSmall
+                        color: Theme.surfaceVariantText
                     }
 
-                    Text {
-                        text: "Details (optional)"
-                        color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                    TextEdit {
+                        width: parent.width
+                        height: Math.max(96, contentHeight + Theme.spacingM)
+                        text: root.addDescription
+                        color: Theme.surfaceText
                         font.pixelSize: Theme.fontSizeMedium
-                        anchors.top: parent.top
-                        anchors.topMargin: Theme.spacingS
-                        anchors.left: parent.left
-                        anchors.leftMargin: Theme.spacingS
-                        visible: root.addDescription === ""
-                    }
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                        onTextChanged: root.addDescription = text
 
-                    leftPadding: Theme.spacingS
-                    rightPadding: Theme.spacingS
-                    topPadding: Theme.spacingS
-                    bottomPadding: Theme.spacingS
+                        Rectangle {
+                            anchors.fill: parent
+                            color: "transparent"
+                            border.width: 1
+                            border.color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                            radius: Theme.cornerRadius
+                            z: -1
+                        }
+
+                        Text {
+                            text: "Optional event details"
+                            color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                            font.pixelSize: Theme.fontSizeMedium
+                            anchors.top: parent.top
+                            anchors.topMargin: Theme.spacingS
+                            anchors.left: parent.left
+                            anchors.leftMargin: Theme.spacingS
+                            visible: root.addDescription === ""
+                        }
+
+                        leftPadding: Theme.spacingS
+                        rightPadding: Theme.spacingS
+                        topPadding: Theme.spacingS
+                        bottomPadding: Theme.spacingS
+                    }
                 }
 
                 // ── Calendar grid date picker ──────────────────────
@@ -1453,41 +1465,51 @@ PluginComponent {
                     verticalAlignment: TextInput.AlignVCenter
                 }
 
-                // Details
-                TextEdit {
+                Column {
                     width: parent.width
-                    height: Math.max(76, contentHeight + Theme.spacingM)
-                    text: root.editDescription
-                    color: Theme.surfaceText
-                    font.pixelSize: Theme.fontSizeMedium
-                    wrapMode: TextEdit.Wrap
-                    selectByMouse: true
-                    onTextChanged: root.editDescription = text
+                    spacing: Theme.spacingXS
 
-                    Rectangle {
-                        anchors.fill: parent
-                        color: "transparent"
-                        border.width: 1
-                        border.color: Theme.withAlpha(Theme.surfaceText, 0.3)
-                        radius: Theme.cornerRadius
-                        z: -1
+                    StyledText {
+                        text: "Details"
+                        font.pixelSize: Theme.fontSizeSmall
+                        color: Theme.surfaceVariantText
                     }
 
-                    Text {
-                        text: "Details (optional)"
-                        color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                    TextEdit {
+                        width: parent.width
+                        height: Math.max(96, contentHeight + Theme.spacingM)
+                        text: root.editDescription
+                        color: Theme.surfaceText
                         font.pixelSize: Theme.fontSizeMedium
-                        anchors.top: parent.top
-                        anchors.topMargin: Theme.spacingS
-                        anchors.left: parent.left
-                        anchors.leftMargin: Theme.spacingS
-                        visible: root.editDescription === ""
-                    }
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                        onTextChanged: root.editDescription = text
 
-                    leftPadding: Theme.spacingS
-                    rightPadding: Theme.spacingS
-                    topPadding: Theme.spacingS
-                    bottomPadding: Theme.spacingS
+                        Rectangle {
+                            anchors.fill: parent
+                            color: "transparent"
+                            border.width: 1
+                            border.color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                            radius: Theme.cornerRadius
+                            z: -1
+                        }
+
+                        Text {
+                            text: "Optional event details"
+                            color: Theme.withAlpha(Theme.surfaceText, 0.3)
+                            font.pixelSize: Theme.fontSizeMedium
+                            anchors.top: parent.top
+                            anchors.topMargin: Theme.spacingS
+                            anchors.left: parent.left
+                            anchors.leftMargin: Theme.spacingS
+                            visible: root.editDescription === ""
+                        }
+
+                        leftPadding: Theme.spacingS
+                        rightPadding: Theme.spacingS
+                        topPadding: Theme.spacingS
+                        bottomPadding: Theme.spacingS
+                    }
                 }
 
                 // Calendar grid for edit
@@ -1811,7 +1833,7 @@ PluginComponent {
                                         text: modelData.description
                                         color: Theme.surfaceVariantText
                                         font.pixelSize: Theme.fontSizeSmall
-                                        visible: (modelData.description || "") !== ""
+                                        visible: root.showDescription && (modelData.description || "") !== ""
                                         width: parent.width
                                         wrapMode: Text.WordWrap
                                         maximumLineCount: 2

--- a/cmd/dankcalendar/cmd_add.go
+++ b/cmd/dankcalendar/cmd_add.go
@@ -18,6 +18,7 @@ func cmdAdd(args []string) {
 	calIdx := fs.Int("calendar", 0, "calendar index")
 	summary := fs.String("summary", "", "event title")
 	location := fs.String("location", "", "event location")
+	description := fs.String("description", "", "event description")
 	startStr := fs.String("start", "", "start time (YYYY-MM-DDTHH:MM or YYYY-MM-DD for all-day)")
 	endStr := fs.String("end", "", "end time (YYYY-MM-DDTHH:MM or YYYY-MM-DD for all-day)")
 	allDay := fs.Bool("all-day", false, "create all-day event")
@@ -73,7 +74,7 @@ func cmdAdd(args []string) {
 
 	uid := generateUID()
 	filename := uid + ".ics"
-	icsData := ical.BuildVEvent(uid, *summary, *location, cfg.Timezone, start, end, *allDay)
+	icsData := ical.BuildVEvent(uid, *summary, *location, *description, cfg.Timezone, start, end, *allDay)
 
 	// Resolve event URL
 	calURL := cal.URL

--- a/cmd/dankcalendar/cmd_edit.go
+++ b/cmd/dankcalendar/cmd_edit.go
@@ -22,6 +22,7 @@ func cmdEdit(args []string) {
 	endDate := fs.String("end-date", "", "new end date (YYYYMMDD)")
 	endTime := fs.String("end-time", "", "new end time (HHMM)")
 	location := fs.String("location", "", "new location (use empty string to clear)")
+	description := fs.String("description", "", "new description (use empty string to clear)")
 	allDay := fs.Bool("all-day", false, "convert to all-day event")
 	fs.Parse(args)
 
@@ -69,7 +70,7 @@ func cmdEdit(args []string) {
 
 	// Apply modifications
 	if *title != "" {
-		icsData = replaceICSLine(icsData, "SUMMARY", ical.EscapeICS(*title))
+		icsData = setICSProperty(icsData, "SUMMARY", ical.EscapeICS(*title))
 	}
 	if *startDate != "" && *startTime != "" {
 		newDT := fmt.Sprintf("DTSTART;TZID=%s:%sT%s00", cfg.Timezone, *startDate, *startTime)
@@ -85,13 +86,11 @@ func cmdEdit(args []string) {
 		newDT := fmt.Sprintf("DTEND;VALUE=DATE:%s", *endDate)
 		icsData = replaceICSPrefixed(icsData, "DTEND", newDT)
 	}
-	if fs.Lookup("location").Value.String() != "" || *location != "" {
-		if hasICSLine(icsData, "LOCATION") {
-			icsData = replaceICSLine(icsData, "LOCATION", ical.EscapeICS(*location))
-		} else if *location != "" {
-			icsData = strings.Replace(icsData, "END:VEVENT",
-				fmt.Sprintf("LOCATION:%s\nEND:VEVENT", ical.EscapeICS(*location)), 1)
-		}
+	if flagProvided(fs, "location") {
+		icsData = setICSProperty(icsData, "LOCATION", ical.EscapeICS(*location))
+	}
+	if flagProvided(fs, "description") {
+		icsData = setICSProperty(icsData, "DESCRIPTION", ical.EscapeICS(*description))
 	}
 
 	// PUT back
@@ -111,27 +110,42 @@ func cmdEdit(args []string) {
 	}
 }
 
-// replaceICSLine replaces the value of a simple ICS property line.
-func replaceICSLine(ics, propName, newValue string) string {
-	var result []string
-	for _, line := range strings.Split(ics, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, propName+":") {
-			result = append(result, propName+":"+newValue)
-		} else {
-			result = append(result, line)
-		}
+func setICSProperty(ics, propName, escapedValue string) string {
+	if hasICSLine(ics, propName) {
+		return replaceICSPrefixed(ics, propName, propName+":"+escapedValue)
 	}
-	return strings.Join(result, "\n")
+	if escapedValue == "" {
+		return ics
+	}
+	return strings.Replace(ics, "END:VEVENT", propName+":"+escapedValue+"\nEND:VEVENT", 1)
+}
+
+func flagProvided(fs *flag.FlagSet, name string) bool {
+	provided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			provided = true
+		}
+	})
+	return provided
 }
 
 // replaceICSPrefixed replaces a line starting with propName (which may have params).
 func replaceICSPrefixed(ics, propName, newLine string) string {
 	var result []string
+	skipFolded := false
 	for _, line := range strings.Split(ics, "\n") {
+		if skipFolded {
+			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+				continue
+			}
+			skipFolded = false
+		}
+
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, propName+";") || strings.HasPrefix(trimmed, propName+":") {
 			result = append(result, newLine)
+			skipFolded = true
 		} else {
 			result = append(result, line)
 		}

--- a/cmd/dankcalendar/cmd_edit_test.go
+++ b/cmd/dankcalendar/cmd_edit_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSetICSPropertyInsertsDescription(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:one\nEND:VEVENT\nEND:VCALENDAR\n"
+
+	got := setICSProperty(ics, "DESCRIPTION", "Bring notes")
+
+	if !strings.Contains(got, "DESCRIPTION:Bring notes\nEND:VEVENT") {
+		t.Fatalf("description was not inserted before END:VEVENT:\n%s", got)
+	}
+}
+
+func TestSetICSPropertyReplacesFoldedDescription(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:one\nDESCRIPTION:Old detail\n continued detail\nEND:VEVENT\nEND:VCALENDAR\n"
+
+	got := setICSProperty(ics, "DESCRIPTION", "New detail")
+
+	if !strings.Contains(got, "DESCRIPTION:New detail\nEND:VEVENT") {
+		t.Fatalf("description was not replaced:\n%s", got)
+	}
+	if strings.Contains(got, "continued detail") {
+		t.Fatalf("folded continuation was not removed:\n%s", got)
+	}
+}
+
+func TestSetICSPropertyClearsExistingDescription(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:one\nDESCRIPTION:Old detail\nEND:VEVENT\nEND:VCALENDAR\n"
+
+	got := setICSProperty(ics, "DESCRIPTION", "")
+
+	if !strings.Contains(got, "DESCRIPTION:\nEND:VEVENT") {
+		t.Fatalf("description was not cleared:\n%s", got)
+	}
+}

--- a/internal/ical/builder.go
+++ b/internal/ical/builder.go
@@ -16,7 +16,7 @@ func EscapeICS(s string) string {
 }
 
 // BuildVEvent generates a complete VCALENDAR with a single VEVENT.
-func BuildVEvent(uid, summary, location, timezone string, start, end time.Time, allDay bool) string {
+func BuildVEvent(uid, summary, location, description, timezone string, start, end time.Time, allDay bool) string {
 	now := time.Now().UTC().Format("20060102T150405Z")
 	summary = EscapeICS(summary)
 
@@ -34,8 +34,13 @@ func BuildVEvent(uid, summary, location, timezone string, start, end time.Time, 
 		locationLine = fmt.Sprintf("LOCATION:%s\n", EscapeICS(location))
 	}
 
-	return fmt.Sprintf("BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//DankCalendar\nBEGIN:VEVENT\nUID:%s\n%s\n%s\nDTSTAMP:%s\nSUMMARY:%s\n%sEND:VEVENT\nEND:VCALENDAR\n",
-		uid, dtstart, dtend, now, summary, locationLine)
+	var descriptionLine string
+	if description != "" {
+		descriptionLine = fmt.Sprintf("DESCRIPTION:%s\n", EscapeICS(description))
+	}
+
+	return fmt.Sprintf("BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//DankCalendar\nBEGIN:VEVENT\nUID:%s\n%s\n%s\nDTSTAMP:%s\nSUMMARY:%s\n%s%sEND:VEVENT\nEND:VCALENDAR\n",
+		uid, dtstart, dtend, now, summary, locationLine, descriptionLine)
 }
 
 // ValidateFilename checks that a filename is safe (no path traversal).

--- a/internal/ical/builder_test.go
+++ b/internal/ical/builder_test.go
@@ -27,7 +27,7 @@ func TestEscapeICS(t *testing.T) {
 func TestBuildVEvent_Timed(t *testing.T) {
 	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
-	ics := BuildVEvent("uid-1", "Meeting", "Room 1", "Europe/Lisbon", start, end, false)
+	ics := BuildVEvent("uid-1", "Meeting", "Room 1", "Bring notes", "Europe/Lisbon", start, end, false)
 
 	if !strings.Contains(ics, "UID:uid-1") {
 		t.Error("missing UID")
@@ -37,6 +37,9 @@ func TestBuildVEvent_Timed(t *testing.T) {
 	}
 	if !strings.Contains(ics, "LOCATION:Room 1") {
 		t.Error("missing LOCATION")
+	}
+	if !strings.Contains(ics, "DESCRIPTION:Bring notes") {
+		t.Error("missing DESCRIPTION")
 	}
 	if !strings.Contains(ics, "DTSTART;TZID=Europe/Lisbon:20260424T100000") {
 		t.Error("wrong DTSTART")
@@ -52,7 +55,7 @@ func TestBuildVEvent_Timed(t *testing.T) {
 func TestBuildVEvent_AllDay(t *testing.T) {
 	start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
-	ics := BuildVEvent("uid-2", "Holiday", "", "UTC", start, end, true)
+	ics := BuildVEvent("uid-2", "Holiday", "", "", "UTC", start, end, true)
 
 	if !strings.Contains(ics, "DTSTART;VALUE=DATE:20260501") {
 		t.Error("wrong DTSTART for all-day")
@@ -63,15 +66,28 @@ func TestBuildVEvent_AllDay(t *testing.T) {
 	if strings.Contains(ics, "LOCATION:") {
 		t.Error("should not have LOCATION when empty")
 	}
+	if strings.Contains(ics, "DESCRIPTION:") {
+		t.Error("should not have DESCRIPTION when empty")
+	}
 }
 
 func TestBuildVEvent_EscapedSummary(t *testing.T) {
 	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
-	ics := BuildVEvent("uid-3", "Test, with; special", "", "UTC", start, end, false)
+	ics := BuildVEvent("uid-3", "Test, with; special", "", "", "UTC", start, end, false)
 
 	if !strings.Contains(ics, "SUMMARY:Test\\, with\\; special") {
 		t.Errorf("summary not escaped properly in: %s", ics)
+	}
+}
+
+func TestBuildVEvent_EscapedDescription(t *testing.T) {
+	start := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
+	ics := BuildVEvent("uid-4", "Meeting", "", "Line one\nLine two, with; detail", "UTC", start, end, false)
+
+	if !strings.Contains(ics, "DESCRIPTION:Line one\\nLine two\\, with\\; detail") {
+		t.Errorf("description not escaped properly in: %s", ics)
 	}
 }
 

--- a/internal/ical/parser.go
+++ b/internal/ical/parser.go
@@ -1,6 +1,7 @@
 package ical
 
 import (
+	"html"
 	"path"
 	"strings"
 	"time"
@@ -31,21 +32,37 @@ func ParseVEvent(icsData, href string, calIdx int, targetTZ string) *Event {
 	lines := unfold(icsData)
 
 	var inEvent bool
+	var nestedDepth int
 	ev := &Event{CalendarIdx: calIdx}
 
 	for _, line := range lines {
-		if line == "BEGIN:VEVENT" {
+		name, params, value := parseLine(line)
+
+		if name == "BEGIN" && value == "VEVENT" {
 			inEvent = true
 			continue
-		}
-		if line == "END:VEVENT" {
-			break
 		}
 		if !inEvent {
 			continue
 		}
 
-		name, params, value := parseLine(line)
+		if name == "BEGIN" {
+			nestedDepth++
+			continue
+		}
+		if name == "END" {
+			if value == "VEVENT" && nestedDepth == 0 {
+				break
+			}
+			if nestedDepth > 0 {
+				nestedDepth--
+			}
+			continue
+		}
+		if nestedDepth > 0 {
+			continue
+		}
+
 		switch name {
 		case "UID":
 			ev.UID = value
@@ -54,7 +71,7 @@ func ParseVEvent(icsData, href string, calIdx int, targetTZ string) *Event {
 		case "LOCATION":
 			ev.Location = unescapeICS(value)
 		case "DESCRIPTION":
-			ev.Description = unescapeICS(value)
+			ev.Description = descriptionText(value)
 		case "DTSTART":
 			ev.Start, ev.AllDay = parseDateTime(value, params, loc)
 		case "DTEND":
@@ -221,4 +238,62 @@ func unescapeICS(s string) string {
 	s = strings.ReplaceAll(s, "\\;", ";")
 	s = strings.ReplaceAll(s, "\\\\", "\\")
 	return s
+}
+
+func descriptionText(s string) string {
+	return htmlToText(unescapeICS(s))
+}
+
+func htmlToText(s string) string {
+	if !strings.Contains(s, "<") {
+		return html.UnescapeString(s)
+	}
+
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] != '<' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+
+		end := strings.IndexByte(s[i:], '>')
+		if end < 0 {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+
+		tag := tagName(s[i+1 : i+end])
+		switch tag {
+		case "br", "div", "li", "p", "tr":
+			appendNewline(&b)
+		}
+		i += end + 1
+	}
+
+	return strings.TrimSpace(html.UnescapeString(b.String()))
+}
+
+func tagName(raw string) string {
+	tag := strings.TrimSpace(strings.ToLower(raw))
+	tag = strings.TrimPrefix(tag, "/")
+	tag = strings.TrimSpace(tag)
+	for i, r := range tag {
+		if r == ' ' || r == '\t' || r == '\r' || r == '\n' || r == '/' {
+			return tag[:i]
+		}
+	}
+	return tag
+}
+
+func appendNewline(b *strings.Builder) {
+	if b.Len() == 0 {
+		return
+	}
+	s := b.String()
+	if strings.HasSuffix(s, "\n") {
+		return
+	}
+	b.WriteByte('\n')
 }

--- a/internal/ical/parser_test.go
+++ b/internal/ical/parser_test.go
@@ -107,6 +107,54 @@ END:VCALENDAR`
 	}
 }
 
+func TestParseVEvent_IgnoresAlarmDescription(t *testing.T) {
+	ics := `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:alarm-1
+SUMMARY:PMU Brows
+DESCRIPTION:Name: Biri Berge\nPhone Number: +47 95 23 62 50\nI've read and agree with <a target="_blank" href="https://annae.tattoo/terms"><strong>Terms of Service</strong></a>: Yes
+DTSTART;TZID=Europe/Oslo:20260704T130000
+DTEND;TZID=Europe/Oslo:20260704T133000
+BEGIN:VALARM
+TRIGGER:-PT10M
+DESCRIPTION:This is an event reminder
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR`
+
+	ev := ParseVEvent(ics, "", 0, "Europe/Oslo")
+	if ev == nil {
+		t.Fatal("expected event, got nil")
+	}
+	want := "Name: Biri Berge\nPhone Number: +47 95 23 62 50\nI've read and agree with Terms of Service: Yes"
+	if ev.Description != want {
+		t.Errorf("Description = %q", ev.Description)
+	}
+}
+
+func TestParseVEvent_AlarmOnlyDescriptionIsIgnored(t *testing.T) {
+	ics := `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:alarm-2
+SUMMARY:Reminder only
+DTSTART;TZID=Europe/Oslo:20260704T130000
+BEGIN:VALARM
+DESCRIPTION:This is an event reminder
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR`
+
+	ev := ParseVEvent(ics, "", 0, "Europe/Oslo")
+	if ev == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if ev.Description != "" {
+		t.Errorf("Description = %q, want empty", ev.Description)
+	}
+}
+
 func TestParseVEvent_UTCTimestamp(t *testing.T) {
 	ics := `BEGIN:VCALENDAR
 BEGIN:VEVENT

--- a/internal/ical/parser_test.go
+++ b/internal/ical/parser_test.go
@@ -37,6 +37,9 @@ END:VCALENDAR`
 	if ev.Location != "Room 42" {
 		t.Errorf("Location = %q, want %q", ev.Location, "Room 42")
 	}
+	if ev.Description != "Weekly sync" {
+		t.Errorf("Description = %q, want %q", ev.Description, "Weekly sync")
+	}
 	if ev.Filename != "test-123.ics" {
 		t.Errorf("Filename = %q, want %q", ev.Filename, "test-123.ics")
 	}

--- a/plugin.json
+++ b/plugin.json
@@ -7,8 +7,8 @@
   "icon": "calendar_month",
   "type": "widget",
   "capabilities": ["dankbar-widget"],
-  "component": "./CalendarWidget.qml",
-  "settings": "./CalendarSettings.qml",
+  "component": "./CalendarWidget.qml?rev=details-v1",
+  "settings": "./CalendarSettings.qml?rev=details-v1",
   "permissions": ["settings_read", "settings_write", "process"],
   "requires": ["dankcalendar", "secret-tool", "notify-send"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "dankCalendar",
   "name": "DankCalendar",
   "description": "CalDAV calendar with events, notifications, and event management",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "alcxyz",
   "icon": "calendar_month",
   "type": "widget",


### PR DESCRIPTION
## Release

Bump DankCalendar to v0.6.0.

## Included changes

- Add editable event details/description support in add and edit flows.
- Add a display setting for event details.
- Show event details in the event list when enabled.
- Ignore nested VALARM descriptions so reminders do not overwrite event details.
- Normalize HTML-ish calendar descriptions into readable plain text.
- Bust QML cache for plugin entrypoints so Nix-managed plugin updates load reliably.

## Validation

- `go test ./...`
- `bash test.sh`