### PR TITLE
Release v0.7.0

### DIFF
--- a/CalendarSettings.qml
+++ b/CalendarSettings.qml
@@ -31,8 +31,9 @@ PluginSettings {
     StringSetting {
         settingKey: "caldavPassword"
         label: "Password"
-        description: "App-specific password for your CalDAV account. Stored securely in the system keyring via secret-tool."
+        description: "App-specific password for your CalDAV account. Stored securely in the system keyring via secret-tool, then cleared from plugin settings."
         placeholder: "Enter password..."
+        password: true
     }
 
     StyledText {

--- a/CalendarWidget.qml
+++ b/CalendarWidget.qml
@@ -90,6 +90,9 @@ PluginComponent {
     }
 
     // ── Sync credentials via dankcalendar discover ──────────────────
+    // The password is handed to the CLI over stdin (never argv, which is
+    // visible in /proc and ps) and is cleared from plugin settings once the
+    // keyring store succeeds, so it does not linger in DMS's plugin data.
     function syncCredentials() {
         if (!caldavUrl || !caldavUsername || !caldavPassword) return;
         var credsKey = caldavUrl + "|" + caldavUsername + "|" + caldavPassword;
@@ -99,19 +102,31 @@ PluginComponent {
         syncProc.command = ["dankcalendar", "discover",
             "--url", caldavUrl,
             "--username", caldavUsername,
-            "--password", caldavPassword,
+            "--password-stdin",
             "--append"];
+        syncProc.stdinEnabled = true;
         syncProc.running = true;
     }
 
     Process {
         id: syncProc
         running: false
+        onStarted: {
+            write(root.caldavPassword + "\n");
+            // Closing stdin sends EOF so the CLI's stdin read completes.
+            stdinEnabled = false;
+        }
         stdout: SplitParser {
             onRead: data => { root._syncOutput += data; }
         }
         onExited: (exitCode, exitStatus) => {
             if (exitCode === 0) {
+                // Credentials are now in the keyring; drop the plaintext copy
+                // that DMS persisted in plugin data.
+                if (root.pluginService && root.pluginService.savePluginData) {
+                    root.pluginService.savePluginData(root.pluginId, "caldavPassword", "");
+                }
+                root.caldavPassword = "";
                 root.fetchEvents();
                 root.fetchCalendars();
             } else {
@@ -1890,7 +1905,11 @@ PluginComponent {
                                     height: meetLinkRow.height
                                     visible: meetLinkRow.visible
                                     cursorShape: Qt.PointingHandCursor
-                                    onClicked: Qt.openUrlExternally(modelData.meetLink)
+                                    onClicked: {
+                                        var link = modelData.meetLink || "";
+                                        if (link.toLowerCase().indexOf("https://") === 0)
+                                            Qt.openUrlExternally(link);
+                                    }
                                 }
                             }
                         }

--- a/cmd/dankcalendar/cmd_discover.go
+++ b/cmd/dankcalendar/cmd_discover.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"flag"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/alcxyz/DankCalendar/internal/caldav"
 	"github.com/alcxyz/DankCalendar/internal/config"
@@ -13,24 +16,34 @@ func cmdDiscover(args []string) {
 	fs := flag.NewFlagSet("discover", flag.ExitOnError)
 	url := fs.String("url", "", "CalDAV server URL")
 	user := fs.String("username", "", "CalDAV username")
-	pw := fs.String("password", "", "CalDAV password")
+	pw := fs.String("password", "", "CalDAV password (avoid; visible in process list)")
+	pwStdin := fs.Bool("password-stdin", false, "read CalDAV password from stdin instead of --password")
 	appendMode := fs.Bool("append", false, "append discovered calendars to existing config instead of replacing")
 	fs.Parse(args)
 
-	if *url == "" || *user == "" || *pw == "" {
-		exitError("--url, --username, and --password are all required")
+	password := *pw
+	if *pwStdin {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			exitError("reading password from stdin: " + err.Error())
+		}
+		password = strings.TrimRight(string(data), "\r\n")
+	}
+
+	if *url == "" || *user == "" || password == "" {
+		exitError("--url, --username, and a password (--password or --password-stdin) are all required")
 	}
 
 	// Store password in keyring
 	if !keyring.Available() {
 		exitError("secret-tool is not installed — install libsecret-tools")
 	}
-	if err := keyring.Store(*user, *pw); err != nil {
+	if err := keyring.Store(*user, password); err != nil {
 		exitError("keyring: " + err.Error())
 	}
 
 	// Discover calendars
-	client, err := caldav.NewClient(*url, *user, *pw)
+	client, err := caldav.NewClient(*url, *user, password)
 	if err != nil {
 		exitError(err.Error())
 	}

--- a/docs/adr/ADR-004-security-defaults.md
+++ b/docs/adr/ADR-004-security-defaults.md
@@ -18,6 +18,10 @@ Apply defense-in-depth across all layers:
 - **URL construction**: Use `url.ResolveReference()` for all URL building — never string concatenation. This applies to `resolveHref` in `internal/caldav/discover.go` (fixed in v0.3.3; prior to v0.3.2 the function used string concatenation, producing malformed paths when `effectiveBase` contained a non-root path).
 - **Config permissions**: Config files are created with `0600` permissions.
 - **No shell expansion**: All subprocess calls use `exec.Command` with explicit argument lists, never shell interpolation.
+- **No credential-forwarding redirects**: The CalDAV client follows redirects manually (`safeRedirect` in `internal/caldav/client.go`) and refuses any redirect that downgrades from HTTPS or changes host, so the `Authorization` header is never replayed to an attacker-controlled or cleartext endpoint.
+- **Password never on argv**: `discover` accepts `--password-stdin`; the QML widget feeds the CalDAV password over stdin so it is not exposed in `/proc/<pid>/cmdline` or `ps`. The legacy `--password` flag remains for manual/CLI use.
+- **Password not persisted in plugin data**: After the keyring store succeeds, the widget clears `caldavPassword` from DMS plugin settings, so the plaintext copy does not linger on disk. The settings field is also masked (`password: true`).
+- **Conference links are HTTPS-only**: `X-GOOGLE-CONFERENCE`/`CONFERENCE` values from (potentially third-party) event data are only surfaced as clickable Meet links when they are `https://` URLs, both in the Go parser and at the `Qt.openUrlExternally` call site, preventing arbitrary URI schemes from reaching the browser/opener.
 
 ## Alternatives Considered
 

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -84,7 +84,11 @@ func (c *Client) Propfind(rawURL, body, depth string) ([]byte, string, error) {
 			resp.StatusCode == 307 || resp.StatusCode == 308 {
 			loc := resp.Header.Get("Location")
 			if loc != "" {
-				currentURL = loc
+				next, err := safeRedirect(currentURL, loc)
+				if err != nil {
+					return nil, currentURL, err
+				}
+				currentURL = next
 				continue
 			}
 		}
@@ -155,6 +159,29 @@ func (c *Client) Get(rawURL string) ([]byte, error) {
 		return nil, fmt.Errorf("GET %s: %d", rawURL, resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
+}
+
+// safeRedirect resolves a redirect Location against the current URL and
+// rejects any redirect that would leave HTTPS or move to a different host.
+// This prevents the Authorization header from being forwarded to an
+// attacker-controlled or cleartext endpoint.
+func safeRedirect(current, location string) (string, error) {
+	base, err := url.Parse(current)
+	if err != nil {
+		return "", fmt.Errorf("invalid redirect origin %q: %w", current, err)
+	}
+	ref, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("invalid redirect target %q: %w", location, err)
+	}
+	next := base.ResolveReference(ref)
+	if next.Scheme != "https" {
+		return "", fmt.Errorf("refusing redirect to non-HTTPS URL %q", next.String())
+	}
+	if !strings.EqualFold(next.Hostname(), base.Hostname()) {
+		return "", fmt.Errorf("refusing cross-host redirect from %q to %q", base.Hostname(), next.Hostname())
+	}
+	return next.String(), nil
 }
 
 // ResolveURL safely resolves a relative path against the base URL.

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -56,3 +56,36 @@ func TestNewClientPreservesBasicAuth(t *testing.T) {
 		t.Fatalf("Authorization = %q, want %q", gotAuth, want)
 	}
 }
+
+func TestSafeRedirect(t *testing.T) {
+	cases := []struct {
+		name     string
+		current  string
+		location string
+		want     string
+		wantErr  bool
+	}{
+		{"same host absolute", "https://dav.example.com/cal/", "https://dav.example.com/principals/", "https://dav.example.com/principals/", false},
+		{"relative path", "https://dav.example.com/cal/", "/principals/user/", "https://dav.example.com/principals/user/", false},
+		{"cross host rejected", "https://dav.example.com/cal/", "https://attacker.example.net/steal", "", true},
+		{"downgrade to http rejected", "https://dav.example.com/cal/", "http://dav.example.com/cal/", "", true},
+		{"host case-insensitive", "https://DAV.example.com/cal/", "https://dav.example.com/x", "https://dav.example.com/x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := safeRedirect(tc.current, tc.location)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("safeRedirect(%q, %q) = %q, want %q", tc.current, tc.location, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ical/parser.go
+++ b/internal/ical/parser.go
@@ -23,6 +23,13 @@ type Event struct {
 	RRule        string `json:"-"`
 }
 
+// isHTTPSURL reports whether value is an https:// URL. Conference links come
+// from event data controlled by the meeting organizer (potentially a third
+// party), so we only surface links the UI can safely hand to the browser.
+func isHTTPSURL(value string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(value)), "https://")
+}
+
 // ParseVEvent extracts a single VEVENT from ICS data.
 // href is the event's URL path, used to derive the filename.
 // targetTZ is the IANA timezone name to normalize timed events into
@@ -79,11 +86,11 @@ func ParseVEvent(icsData, href string, calIdx int, targetTZ string) *Event {
 		case "RRULE":
 			ev.RRule = value
 		case "X-GOOGLE-CONFERENCE":
-			if ev.MeetLink == "" {
+			if ev.MeetLink == "" && isHTTPSURL(value) {
 				ev.MeetLink = value
 			}
 		case "CONFERENCE":
-			if ev.MeetLink == "" {
+			if ev.MeetLink == "" && isHTTPSURL(value) {
 				ev.MeetLink = value
 			}
 		case "ATTENDEE":

--- a/internal/ical/parser_test.go
+++ b/internal/ical/parser_test.go
@@ -275,3 +275,43 @@ END:VCALENDAR`
 		t.Errorf("MeetLink = %q, want Zoom URL", ev.MeetLink)
 	}
 }
+
+func TestParseVEvent_RejectsNonHTTPSMeetLink(t *testing.T) {
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:evil@example.com
+SUMMARY:Sketchy meeting
+DTSTART:20260101T100000Z
+DTEND:20260101T110000Z
+X-GOOGLE-CONFERENCE:file:///etc/passwd
+END:VEVENT
+END:VCALENDAR`
+	ev := ParseVEvent(ics, "/cal/evil.ics", 0, "")
+	if ev == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if ev.MeetLink != "" {
+		t.Errorf("MeetLink = %q, want empty (non-https scheme must be dropped)", ev.MeetLink)
+	}
+}
+
+func TestParseVEvent_AcceptsHTTPSMeetLink(t *testing.T) {
+	ics := `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:ok@example.com
+SUMMARY:Real meeting
+DTSTART:20260101T100000Z
+DTEND:20260101T110000Z
+CONFERENCE:https://meet.google.com/abc-defg-hij
+END:VEVENT
+END:VCALENDAR`
+	ev := ParseVEvent(ics, "/cal/ok.ics", 0, "")
+	if ev == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if ev.MeetLink != "https://meet.google.com/abc-defg-hij" {
+		t.Errorf("MeetLink = %q, want the https URL", ev.MeetLink)
+	}
+}

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "id": "dankCalendar",
   "name": "DankCalendar",
   "description": "CalDAV calendar with events, notifications, and event management",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "alcxyz",
   "icon": "calendar_month",
   "type": "widget",


### PR DESCRIPTION
## Summary
- Release DankCalendar v0.7.0
- Harden CalDAV credential handling by supporting stdin password delivery and clearing stored plaintext after successful keyring sync
- Block unsafe CalDAV redirects that downgrade HTTPS or change host
- Restrict clickable conference links to HTTPS URLs

## Validation
- `go test ./...`
- `bash test.sh`

## Note
- `../scripts/check-plugin-ci.sh` currently reports DankCalendar workflow/template drift because the release workflow was hardened before the shared aggregator template was updated. The plugin CI itself passes.