### PR TITLE
Fix release tag existence check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,8 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           TARGET_SHA="$(git rev-parse HEAD)"
-          EXISTING_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${VERSION}" --jq ".object.sha" 2>/dev/null || true)"
 
-          if [ -n "$EXISTING_SHA" ]; then
+          if EXISTING_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${VERSION}" --jq ".object.sha" 2>/dev/null)"; then
             if [ "$EXISTING_SHA" != "$TARGET_SHA" ]; then
               echo "Tag $VERSION already exists at $EXISTING_SHA; this main push is not a new release."
               echo "should_release=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix the release workflow's tag-existence check so a GitHub 404 response is not treated as an existing tag SHA
- Keep non-version `main` pushes skipping release publishing when an existing tag points elsewhere

## Validation
- `bash -n` over extracted workflow `run` snippets
- `git diff --check`

## Context
The `v0.7.0` release was published manually after the workflow skipped release creation because the missing-tag API response was captured as stdout.